### PR TITLE
Add TypeScript definition and `useNativeDriver` property

### DIFF
--- a/FadeInOut.d.ts
+++ b/FadeInOut.d.ts
@@ -1,0 +1,12 @@
+import React from 'react'
+import {ViewProps, ViewStyle} from 'react-native'
+
+export interface FadeInOutProps extends ViewProps {
+    visible: boolean
+    duration?: number
+    rotate?: boolean
+    scale?: boolean
+    style?: ViewStyle
+    useNativeDriver?: boolean
+}
+export default class FadeInOut extends React.Component<FadeInOutProps, {}> {}

--- a/FadeInOut.js
+++ b/FadeInOut.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {Animated} from 'react-native';
 
 export const DEFAULT_DURATION = 300;
+const DEFAULT_USE_NATIVE_DRIVER = true;
 
 export default class FadeInOut extends PureComponent {
   static propTypes = {
@@ -12,6 +13,7 @@ export default class FadeInOut extends PureComponent {
     rotate: PropTypes.bool,
     scale: PropTypes.bool,
     style: PropTypes.object,
+    useNativeDriver: PropTypes.bool,
   };
 
   state = {
@@ -19,12 +21,13 @@ export default class FadeInOut extends PureComponent {
   };
 
   componentDidUpdate(prevProps) {
-    const {duration} = this.props;
+    const {duration, useNativeDriver} = this.props;
 
     if (prevProps.visible !== this.props.visible) {
       Animated.timing(this.state.fadeAnim, {
         toValue: prevProps.visible ? 0 : 1,
         duration: duration ? duration : DEFAULT_DURATION,
+        useNativeDriver: useNativeDriver ? useNativeDriver : DEFAULT_USE_NATIVE_DRIVER
       }).start();
     }
   }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Adds scaling from %0 to %100 on fade in and %100 to %0 on fade out.
 |:------------------------------|----------|
 | [View styles][view-styles-url]| No       |
 
+### `useNativeDriver`
+By default, we use the native driver for opacity and transform animations. If for some reason
+you need to turn this off, you can do so with this property. The default value is `true`.
+
+| Type       | Required |
+|:-----------|----------|
+| Boolean    | No       |
+
+See [React Native Native Driver blog post][react-native-blog] for more details.
+
 ## License
 
 MIT © [Courtney Pattison][courtney-url]
@@ -106,6 +116,7 @@ MIT © [Courtney Pattison][courtney-url]
 [npm-img]: https://img.shields.io/npm/v/react-native-fade-in-out.svg
 [npm-url]: https://www.npmjs.com/package/react-native-fade-in-out
 
+[react-native-blog]: https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated#caveats
 [react-native-url]: https://facebook.github.io/react-native/
 
 [travis-img]: https://img.shields.io/travis/courtneypattison/react-native-fade-in-out.svg

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "author": "courtneypattison <courtneyp@ttison.ca> (https://courtneypattison.com/)",
   "license": "MIT",
   "files": [
-    "/FadeInOut.js"
+    "/FadeInOut.js",
+    "/FadeInOut.d.ts"
   ],
   "keywords": [
     "fade",


### PR DESCRIPTION
Hi @courtneypattison!

I found your library and this probably saved me a bunch of time figuring out how to fade-in-out properly.

I'm using TypeScript in my project and wanted to add those definitions and squash the warning for `useNativeDriver`. I set the default value to `true` because it seems this library only uses opacity and transform animations so I think `true` should be fine for everyone. Happy to flip it to `false` if you prefer.

Thanks!